### PR TITLE
Use McpGpioPin and GpioPin for relays too

### DIFF
--- a/code/espurna/button.cpp
+++ b/code/espurna/button.cpp
@@ -716,14 +716,21 @@ void buttonSetup() {
 
         _buttons.reserve(buttons);
 
+        // TODO: allow to change gpio pin type based on config?
+        #if (BUTTON_EVENTS_SOURCE == BUTTON_EVENTS_SOURCE_GENERIC)
+            using gpio_type = GpioPin;
+        #elif (BUTTON_EVENTS_SOURCE == BUTTON_EVENTS_SOURCE_MCP23S08)
+            using gpio_type = McpGpioPin;
+        #endif
+
         for (unsigned char index = 0; index < ButtonsMax; ++index) {
             const auto pin = getSetting({"btnGPIO", index}, _buttonPin(index));
-            #if (BUTTON_EVENTS_SOURCE == BUTTON_EVENTS_SOURCE_MCP23S08)
-                if (!mcpGpioValid(pin)) {
+            #if (BUTTON_EVENTS_SOURCE == BUTTON_EVENTS_SOURCE_GENERIC)
+                if (!gpioValid(pin)) {
                     break;
                 }
-            #else
-                if (!gpioValid(pin)) {
+            #elif (BUTTON_EVENTS_SOURCE == BUTTON_EVENTS_SOURCE_MCP23S08)
+                if (!mcpGpioValid(pin)) {
                     break;
                 }
             #endif
@@ -749,19 +756,10 @@ void buttonSetup() {
 
             const auto config = _buttonConfig(index);
 
-            #if BUTTON_EVENTS_SOURCE == BUTTON_EVENTS_SOURCE_MCP23S08
-            // TODO: allow to change McpGpioPin to something else based on config?
             _buttons.emplace_back(
-                std::make_shared<McpGpioPin>(pin), config,
+                std::make_shared<gpio_type>(pin), config,
                 relayID, actions, delays
             );
-            #else
-            // TODO: allow to change GpioPin to something else based on config?
-            _buttons.emplace_back(
-                std::make_shared<GpioPin>(pin), config,
-                relayID, actions, delays
-            );
-            #endif
         }
 
     #endif

--- a/code/espurna/button.cpp
+++ b/code/espurna/button.cpp
@@ -718,15 +718,16 @@ void buttonSetup() {
 
         for (unsigned char index = 0; index < ButtonsMax; ++index) {
             const auto pin = getSetting({"btnGPIO", index}, _buttonPin(index));
-            #if (BUTTON_EVENTS_SOURCE != BUTTON_EVENTS_SOURCE_MCP23S08)
-            if (!gpioValid(pin)) {
-                break;
-            }
+            #if (BUTTON_EVENTS_SOURCE == BUTTON_EVENTS_SOURCE_MCP23S08)
+                if (!mcpGpioValid(pin)) {
+                    break;
+                }
             #else
-            if (pin > 4) {
-                break;
-            }
+                if (!gpioValid(pin)) {
+                    break;
+                }
             #endif
+
             const auto relayID = getSetting({"btnRelay", index}, _buttonRelay(index));
 
             // TODO: compatibility proxy, fetch global key before indexed

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1779,8 +1779,17 @@
 //--------------------------------------------------------------------------------
 // Support expander MCP23S08
 //--------------------------------------------------------------------------------
+
 #ifndef MCP23S08_SUPPORT
 #define MCP23S08_SUPPORT            0
+#endif
+
+#ifndef MCP23S08_CS_PIN
+#define MCP23S08_CS_PIN             15
+#endif
+
+#ifndef MCP23S08_SPI_FREQUENCY
+#define MCP23S08_SPI_FREQUENCY      1000000
 #endif
 
 // =============================================================================

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1784,14 +1784,6 @@
 #define MCP23S08_SUPPORT            0
 #endif
 
-#ifndef MCP23S08_CS_PIN
-#define MCP23S08_CS_PIN             15
-#endif
-
-#ifndef MCP23S08_SPI_FREQUENCY
-#define MCP23S08_SPI_FREQUENCY      1000000
-#endif
-
 // =============================================================================
 // Configuration helpers
 // =============================================================================

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -4828,47 +4828,36 @@
     // MCP23S08
     #define MCP23S08_SUPPORT        1
 
-    #define MCP23S08_OPTOIN_COUNT   4
-
-    // Opto input pins
-    #define MCP23S08_IN1PIN         0
-    #define MCP23S08_IN2PIN         1
-    #define MCP23S08_IN3PIN         2
-    #define MCP23S08_IN4PIN         3
-
-    // Relay pins
-    #define MCP23S08_REL1PIN        4
-    #define MCP23S08_REL2PIN        5
-    #define MCP23S08_REL3PIN        6
-    #define MCP23S08_REL4PIN        7
-
     // Relays
-    #define DUMMY_RELAY_COUNT       4
     #define RELAY_PROVIDER          RELAY_PROVIDER_MCP23S08
+    #define RELAY1_PIN              4
+    #define RELAY2_PIN              5
+    #define RELAY3_PIN              6
+    #define RELAY4_PIN              7
 
     // Buttons
-    #define BUTTON1_CONFIG          BUTTON_PUSHBUTTON
-    #define BUTTON1_PIN             MCP23S08_IN1PIN
+    #define BUTTON1_CONFIG          BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_PIN             0
 
-    #define BUTTON2_CONFIG          BUTTON_PUSHBUTTON
-    #define BUTTON2_PIN             MCP23S08_IN2PIN
+    #define BUTTON2_CONFIG          BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON2_PIN             1
 
-    #define BUTTON3_CONFIG          BUTTON_PUSHBUTTON
-    #define BUTTON3_PIN             MCP23S08_IN3PIN
+    #define BUTTON3_CONFIG          BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON3_PIN             2
 
-    #define BUTTON4_CONFIG          BUTTON_PUSHBUTTON
-    #define BUTTON4_PIN             MCP23S08_IN4PIN
+    #define BUTTON4_CONFIG          BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON4_PIN             3
 
-    #define BUTTON1_RELAY       1
-    #define BUTTON2_RELAY       2
-    #define BUTTON3_RELAY       3
-    #define BUTTON4_RELAY       4
+    #define BUTTON1_RELAY           1
+    #define BUTTON2_RELAY           2
+    #define BUTTON3_RELAY           3
+    #define BUTTON4_RELAY           4
 
     #define BUTTON_EVENTS_SOURCE    BUTTON_EVENTS_SOURCE_MCP23S08
 
     // LEDs
-    #define LED1_PIN            2
-    #define LED1_PIN_INVERSE    1
+    #define LED1_PIN                2
+    #define LED1_PIN_INVERSE        1
 
 // -----------------------------------------------------------------------------
 

--- a/code/espurna/domoticz.cpp
+++ b/code/espurna/domoticz.cpp
@@ -19,7 +19,7 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 #include "ws.h"
 
 bool _dcz_enabled = false;
-std::bitset<RELAYS_MAX> _dcz_relay_state;
+std::bitset<RelaysMax> _dcz_relay_state;
 
 //------------------------------------------------------------------------------
 // Private methods

--- a/code/espurna/libs/BasePin.h
+++ b/code/espurna/libs/BasePin.h
@@ -11,15 +11,18 @@ Copyright (C) 2020 by Maxim Prokhorov <prokhorov dot max at outlook dot com>
 #include <cstdint>
 
 // base interface for generic pin handler. 
-class BasePin {
-    public:
-        BasePin(unsigned char pin) :
-            pin(pin)
-        {}
+struct BasePin {
+    BasePin(unsigned char pin) :
+        pin(pin)
+    {}
 
-        virtual void pinMode(int8_t mode) = 0;
-        virtual void digitalWrite(int8_t val) = 0;
-        virtual int digitalRead() = 0;
+    virtual operator bool() {
+        return GPIO_NONE != pin;
+    }
 
-        const unsigned char pin;
+    virtual void pinMode(int8_t mode) = 0;
+    virtual void digitalWrite(int8_t val) = 0;
+    virtual int digitalRead() = 0;
+
+    const unsigned char pin;
 };

--- a/code/espurna/main.cpp
+++ b/code/espurna/main.cpp
@@ -194,6 +194,11 @@ void setup() {
         apiSetup();
     #endif
 
+    // Hardware GPIO expander, needs to be available for modules down below
+    #if MCP23S08_SUPPORT
+        MCP23S08Setup();
+    #endif
+
     // lightSetup must be called before relaySetup
     #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
         lightSetup();
@@ -289,10 +294,6 @@ void setup() {
     #endif
     #if KINGART_CURTAIN_SUPPORT
         kingartCurtainSetup();
-    #endif
-
-    #if MCP23S08_SUPPORT
-        MCP23S08Setup();
     #endif
 
     // 3rd party code hook

--- a/code/espurna/mcp23s08.cpp
+++ b/code/espurna/mcp23s08.cpp
@@ -54,13 +54,12 @@ inline int McpGpioPin::digitalRead() {
 
 void MCP23S08Setup()
 {
-    // Expander SPI settings
-    DEBUG_MSG_P(PSTR("[MCP23S08] Pin=%u SPI bus %u Hz\n"),
-        MCP23S08_CS_PIN, MCP23S08_SPI_FREQUENCY);
+    DEBUG_MSG_P(PSTR("[MCP23S08] Initialize SPI bus\n"));
 
+    // Expander SPI settings
     SPI.begin();
-    SPI.setHwCs(MCP23S08_CS_PIN);
-    SPI.setFrequency(MCP23S08_SPI_FREQUENCY);
+    SPI.setHwCs(true);
+    SPI.setFrequency(1000000);
     SPI.setDataMode(SPI_MODE0);
 
     pinMode(MCP23S08_CS_PIN, OUTPUT);

--- a/code/espurna/mcp23s08.cpp
+++ b/code/espurna/mcp23s08.cpp
@@ -16,6 +16,9 @@ Copyright (C) 2016 Plamen Kovandjiev <p.kovandiev@kmpelectronics.eu> & Dimitar A
 
 #include <bitset>
 
+// TODO: check if this needed for SPI operation
+#define MCP23S08_CS_PIN 15
+
 // Known commands
 #define READ_CMD  0x41
 #define WRITE_CMD 0x40

--- a/code/espurna/mcp23s08.h
+++ b/code/espurna/mcp23s08.h
@@ -18,12 +18,10 @@ Copyright (C) 2016-2017 Plamen Kovandjiev <p.kovandiev@kmpelectronics.eu> & Dimi
 
 #if MCP23S08_SUPPORT
 
-#include <SPI.h>
-
-constexpr const size_t McpGpioPins = MCP23S08_OPTOIN_COUNT;
+constexpr size_t McpGpioPins = 8;
 
 // real hardware pin
-class McpGpioPin final : virtual public BasePin {
+class McpGpioPin final : public BasePin {
     public:
         McpGpioPin(unsigned char pin);
 
@@ -32,18 +30,14 @@ class McpGpioPin final : virtual public BasePin {
         int digitalRead();
 };
 
-// Inputs and outputs count.
-#define MCP23S08_OPTOIN_COUNT 4
-
 void MCP23S08Setup();
-void MCP23S08InitGPIO(); 
-void MCP23S08SetDirection(uint8_t pinNumber, uint8_t mode);
+
 uint8_t MCP23S08ReadRegister(uint8_t address);
 void MCP23S08WriteRegister(uint8_t address, uint8_t data);
+
+void MCP23S08SetDirection(uint8_t pinNumber, uint8_t mode);
 void MCP23S08SetPin(uint8_t pinNumber, bool state);
 bool MCP23S08GetPin(uint8_t pinNumber);
-void MCP23S08SetRelayState(uint8_t relayNumber, bool state);
-bool MCP23S08GetOptoInState(uint8_t optoInNumber);
 
 bool mcpGpioValid(unsigned char gpio);
 

--- a/code/espurna/relay.cpp
+++ b/code/espurna/relay.cpp
@@ -1443,15 +1443,6 @@ void relaySetupDummy(size_t size, bool reconfigure) {
 
 }
 
-template <typename T>
-relay_t _relayFromConfiguration(unsigned char id) { 
-    return {
-        std::make_unique<T>(_relayPin(id)),
-        _relayType(id),
-        std::make_unique<T>(_relayResetPin(id))
-    };
-}
-
 void _relaySetupAdhoc() {
 
     size_t relays [[gnu::unused]] = 0;
@@ -1483,9 +1474,9 @@ void _relaySetupAdhoc() {
 
     _relays.reserve(relays);
 
-    #if RELAY_PROVIDER == RELAY_PROVIDER_RELAY
+    #if (RELAY_PROVIDER == RELAY_PROVIDER_RELAY)
         using gpio_type = GpioPin;
-    #elif RELAY_PROVIDER == RELAY_PROVIDER_MCP23S08
+    #elif (RELAY_PROVIDER == RELAY_PROVIDER_MCP23S08)
         using gpio_type = McpGpioPin;
     #endif
 

--- a/code/espurna/relay.cpp
+++ b/code/espurna/relay.cpp
@@ -28,21 +28,32 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 #include "tuya.h"
 #include "utils.h"
 #include "ws.h"
-
-#if MCP23S08_SUPPORT
 #include "mcp23s08.h"
-#endif
+
+#include "libs/BasePin.h"
 
 #include "relay_config.h"
 
+struct DummyPin final : public BasePin {
+    DummyPin(unsigned char pin) :
+        BasePin(pin)
+    {}
+
+    void pinMode(int8_t) override {}
+    void digitalWrite(int8_t) override {}
+    int digitalRead() override { return 0; }
+};
+
 struct relay_t {
 
-    // Default to dummy (virtual) relay configuration
+    using pin_type = std::unique_ptr<BasePin>;
 
-    relay_t(unsigned char pin, unsigned char type, unsigned char reset_pin) :
-        pin(pin),
+    // Default to empty relay configuration, as we allow switches to exist without real GPIOs
+
+    relay_t(pin_type&& pin, unsigned char type, pin_type&& reset_pin) :
+        pin(std::move(pin)),
+        reset_pin(std::move(reset_pin)),
         type(type),
-        reset_pin(reset_pin),
         delay_on(0),
         delay_off(0),
         pulse(RELAY_PULSE_NONE),
@@ -59,20 +70,13 @@ struct relay_t {
     {}
 
     relay_t() :
-        relay_t(GPIO_NONE, RELAY_TYPE_NORMAL, GPIO_NONE)
+        relay_t(std::make_unique<DummyPin>(GPIO_NONE), RELAY_TYPE_NORMAL, std::make_unique<DummyPin>(GPIO_NONE))
     {}
 
-    // ... unless there are pre-configured values
+    pin_type pin;                // GPIO pin for the relay
+    pin_type reset_pin;          // GPIO to reset the relay if RELAY_TYPE_LATCHED
 
-    relay_t(unsigned char id) :
-        relay_t(_relayPin(id), _relayType(id), _relayResetPin(id))
-    {}
-
-    // Configuration variables
-
-    unsigned char pin;           // GPIO pin for the relay
     unsigned char type;          // RELAY_TYPE_NORMAL, RELAY_TYPE_INVERSE, RELAY_TYPE_LATCHED or RELAY_TYPE_LATCHED_INVERSE
-    unsigned char reset_pin;     // GPIO to reset the relay if RELAY_TYPE_LATCHED
     unsigned long delay_on;      // Delay to turn relay ON
     unsigned long delay_off;     // Delay to turn relay OFF
     unsigned char pulse;         // RELAY_PULSE_NONE, RELAY_PULSE_OFF or RELAY_PULSE_ON
@@ -269,12 +273,6 @@ void _relayProviderStatus(unsigned char id, bool status) {
         Serial.flush();
     #endif
 
-    #if RELAY_PROVIDER == RELAY_PROVIDER_MCP23S08
-        DEBUG_MSG_P(PSTR("[RELAY] [MCP23S08] Set relay %d to %s\n"), id, status ? "ON": "OFF");
-
-        MCP23S08SetRelayState((uint8_t) id, status);
-    #endif
-
     #if RELAY_PROVIDER == RELAY_PROVIDER_LIGHT
 
         // Real relays
@@ -310,27 +308,33 @@ void _relayProviderStatus(unsigned char id, bool status) {
 
     #endif
 
-    #if (RELAY_PROVIDER == RELAY_PROVIDER_RELAY) || (RELAY_PROVIDER == RELAY_PROVIDER_LIGHT)
+    #if (RELAY_PROVIDER == RELAY_PROVIDER_RELAY) || \
+        (RELAY_PROVIDER == RELAY_PROVIDER_LIGHT) || \
+        (RELAY_PROVIDER == RELAY_PROVIDER_MCP23S08)
 
         // If this is a light, all dummy relays have already been processed above
         // we reach here if the user has toggled a physical relay
 
         if (_relays[id].type == RELAY_TYPE_NORMAL) {
-            digitalWrite(_relays[id].pin, status);
+            _relays[id].pin->digitalWrite(status);
         } else if (_relays[id].type == RELAY_TYPE_INVERSE) {
-            digitalWrite(_relays[id].pin, !status);
+            _relays[id].pin->digitalWrite(!status);
         } else if (_relays[id].type == RELAY_TYPE_LATCHED || _relays[id].type == RELAY_TYPE_LATCHED_INVERSE) {
             bool pulse = (_relays[id].type == RELAY_TYPE_LATCHED) ? HIGH : LOW;
-            digitalWrite(_relays[id].pin, !pulse);
-            if (GPIO_NONE != _relays[id].reset_pin) digitalWrite(_relays[id].reset_pin, !pulse);
-            if (status || (GPIO_NONE == _relays[id].reset_pin)) {
-                digitalWrite(_relays[id].pin, pulse);
+            _relays[id].pin->digitalWrite(!pulse);
+            if (GPIO_NONE != _relays[id].reset_pin->pin) {
+                _relays[id].reset_pin->digitalWrite(!pulse);
+            }
+            if (status || (GPIO_NONE == _relays[id].reset_pin->pin)) {
+                _relays[id].pin->digitalWrite(pulse);
             } else {
-                digitalWrite(_relays[id].reset_pin, pulse);
+                _relays[id].reset_pin->digitalWrite(pulse);
             }
             nice_delay(RELAY_LATCHING_PULSE);
-            digitalWrite(_relays[id].pin, !pulse);
-            if (GPIO_NONE != _relays[id].reset_pin) digitalWrite(_relays[id].reset_pin, !pulse);
+            _relays[id].pin->digitalWrite(!pulse);
+            if (GPIO_NONE != _relays[id].reset_pin->pin) {
+                _relays[id].reset_pin->digitalWrite(!pulse);
+            }
         }
 
     #endif
@@ -481,7 +485,7 @@ void INLINE _relayMaskRtcmem(const RelayMask& mask) {
     _relayMaskRtcmem(mask.as_u32);
 }
 
-void INLINE _relayMaskRtcmem(const std::bitset<RELAYS_MAX>& bitset) {
+void INLINE _relayMaskRtcmem(const std::bitset<RelaysMax>& bitset) {
     _relayMaskRtcmem(bitset.to_ulong());
 }
 
@@ -499,7 +503,7 @@ void INLINE _relayMaskSettings(const RelayMask& mask) {
     setSetting("relayBootMask", mask.as_string);
 }
 
-void INLINE _relayMaskSettings(const std::bitset<RELAYS_MAX>& bitset) {
+void INLINE _relayMaskSettings(const std::bitset<RelaysMax>& bitset) {
     _relayMaskSettings(bitset.to_ulong());
 }
 
@@ -692,9 +696,9 @@ void relaySync(unsigned char id) {
 
 void relaySave(bool eeprom) {
 
-    const unsigned char count = constrain(relayCount(), 0, RELAYS_MAX);
+    const unsigned char count = constrain(relayCount(), 0, RelaysMax);
 
-    auto statuses = std::bitset<RELAYS_MAX>(0);
+    auto statuses = std::bitset<RelaysMax>(0);
     for (unsigned int id = 0; id < count; ++id) {
         statuses.set(id, relayStatus(id));
     }
@@ -787,7 +791,7 @@ void _relayBoot() {
 
     DEBUG_MSG_P(PSTR("[RELAY] Retrieving mask: %s\n"), stored_mask.as_string.c_str());
 
-    auto mask = std::bitset<RELAYS_MAX>(stored_mask.as_u32);
+    auto mask = std::bitset<RelaysMax>(stored_mask.as_u32);
 
     // Walk the relays
     unsigned char lock;
@@ -856,15 +860,17 @@ void _relayConfigure() {
         _relays[i].delay_on = getSetting({"relayDelayOn", i}, _relayDelayOn(i));
         _relays[i].delay_off = getSetting({"relayDelayOff", i}, _relayDelayOff(i));
 
-        if (GPIO_NONE == _relays[i].pin) continue;
+        // make sure pin is valid before continuing with writes
+        if (!static_cast<bool>(*_relays[i].pin)) continue;
 
-        pinMode(_relays[i].pin, OUTPUT);
-        if (GPIO_NONE != _relays[i].reset_pin) {
-            pinMode(_relays[i].reset_pin, OUTPUT);
+        _relays[i].pin->pinMode(OUTPUT);
+        if (static_cast<bool>(*_relays[i].reset_pin)) {
+            _relays[i].reset_pin->pinMode(OUTPUT);
         }
+
         if (_relays[i].type == RELAY_TYPE_INVERSE) {
             //set to high to block short opening of relay
-            digitalWrite(_relays[i].pin, HIGH);
+            _relays[i].pin->digitalWrite(HIGH);
         }
     }
 
@@ -908,9 +914,9 @@ void _relayWebSocketUpdate(JsonObject& root) {
 }
 
 String _relayFriendlyName(unsigned char i) {
-    String res = String("GPIO") + String(_relays[i].pin);
+    String res = String("GPIO") + String(_relays[i].pin->pin);
 
-    if (GPIO_NONE == _relays[i].pin) {
+    if (GPIO_NONE == _relays[i].pin->pin) {
         #if (RELAY_PROVIDER == RELAY_PROVIDER_LIGHT)
             uint8_t physical = _relays.size() - _relayDummy;
             if (i >= physical) {
@@ -963,7 +969,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
         gpio.add(_relayFriendlyName(i));
 
         type.add(_relays[i].type);
-        reset.add(_relays[i].reset_pin);
+        reset.add(_relays[i].reset_pin->pin);
         boot.add(getSetting({"relayBoot", i}, RELAY_BOOT_MODE));
 
         pulse.add(_relays[i].pulse);
@@ -1422,7 +1428,7 @@ void relaySetupDummy(size_t size, bool reconfigure) {
     if (size == _relayDummy) return;
 
     const size_t new_size = ((_relays.size() - _relayDummy) + size);
-    if (new_size > RELAYS_MAX) return;
+    if (new_size > RelaysMax) return;
 
     _relayDummy = size;
     _relays.resize(new_size);
@@ -1437,9 +1443,18 @@ void relaySetupDummy(size_t size, bool reconfigure) {
 
 }
 
+template <typename T>
+relay_t _relayFromConfiguration(unsigned char id) { 
+    return {
+        std::make_unique<T>(_relayPin(id)),
+        _relayType(id),
+        std::make_unique<T>(_relayResetPin(id))
+    };
+}
+
 void _relaySetupAdhoc() {
 
-    size_t relays = 0;
+    size_t relays [[gnu::unused]] = 0;
 
     #if RELAY1_PIN != GPIO_NONE
         ++relays;
@@ -1467,8 +1482,30 @@ void _relaySetupAdhoc() {
     #endif
 
     _relays.reserve(relays);
-    for (unsigned char id = 0; id < relays; ++id) {
-        _relays.emplace_back(id);
+
+    #if RELAY_PROVIDER == RELAY_PROVIDER_RELAY
+        using gpio_type = GpioPin;
+    #elif RELAY_PROVIDER == RELAY_PROVIDER_MCP23S08
+        using gpio_type = McpGpioPin;
+    #endif
+
+    for (unsigned char id = 0; id < RelaysMax; ++id) {
+        const auto pin = _relayPin(id);
+        #if RELAY_PROVIDER == RELAY_PROVIDER_RELAY
+            if (!gpioValid(pin)) {
+                break;
+            }
+        #elif RELAY_PROVIDER == RELAY_PROVIDER_MCP23S08
+            if (!mcpGpioValid(pin)) {
+                break;
+            }
+        #endif
+
+        _relays.emplace_back(
+            std::make_unique<gpio_type>(_relayPin(id)),
+            _relayType(id),
+            std::make_unique<gpio_type>(_relayResetPin(id))
+        );
     }
 
 }

--- a/code/espurna/relay.h
+++ b/code/espurna/relay.h
@@ -13,7 +13,7 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #include <bitset>
 
-constexpr size_t RELAYS_MAX = 32; 
+constexpr size_t RelaysMax = 32;
 
 PayloadStatus relayParsePayload(const char * payload);
 


### PR DESCRIPTION
(not to push directly into the dev branch)

- relays now use Gpio class
- slightly adjusted Gpio checks. I think we are safe to assume 0...7 is a valid range.
- no more dummy relays, no more optin flags, no more relays / buttons in mcp itself
- digitalread now returns non-inverted result

Regarding gpioValid usage / question from earlier - `gpio_type::valid(...)` can be it, but as static not virtual.